### PR TITLE
Fix SettingsPage bugs and show correct local time on home screen

### DIFF
--- a/flutter_app/lib/generated/temperature.pb.dart
+++ b/flutter_app/lib/generated/temperature.pb.dart
@@ -217,10 +217,12 @@ class TemperatureReading extends $pb.GeneratedMessage {
   factory TemperatureReading({
     $core.double? value,
     $core.String? unit,
+    $core.int? utcOffsetSeconds,
   }) {
     final result = create();
     if (value != null) result.value = value;
     if (unit != null) result.unit = unit;
+    if (utcOffsetSeconds != null) result.utcOffsetSeconds = utcOffsetSeconds;
     return result;
   }
 
@@ -240,6 +242,7 @@ class TemperatureReading extends $pb.GeneratedMessage {
       createEmptyInstance: create)
     ..aD(1, _omitFieldNames ? '' : 'value', fieldType: $pb.PbFieldType.OF)
     ..aOS(2, _omitFieldNames ? '' : 'unit')
+    ..aI(3, _omitFieldNames ? '' : 'utcOffsetSeconds')
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
@@ -278,6 +281,15 @@ class TemperatureReading extends $pb.GeneratedMessage {
   $core.bool hasUnit() => $_has(1);
   @$pb.TagNumber(2)
   void clearUnit() => $_clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.int get utcOffsetSeconds => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set utcOffsetSeconds($core.int value) => $_setSignedInt32(2, value);
+  @$pb.TagNumber(3)
+  $core.bool hasUtcOffsetSeconds() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearUtcOffsetSeconds() => $_clearField(3);
 }
 
 const $core.bool _omitFieldNames =

--- a/flutter_app/lib/generated/temperature.pbjson.dart
+++ b/flutter_app/lib/generated/temperature.pbjson.dart
@@ -66,10 +66,17 @@ const TemperatureReading$json = {
   '2': [
     {'1': 'value', '3': 1, '4': 1, '5': 2, '10': 'value'},
     {'1': 'unit', '3': 2, '4': 1, '5': 9, '10': 'unit'},
+    {
+      '1': 'utc_offset_seconds',
+      '3': 3,
+      '4': 1,
+      '5': 5,
+      '10': 'utcOffsetSeconds'
+    },
   ],
 };
 
 /// Descriptor for `TemperatureReading`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List temperatureReadingDescriptor = $convert.base64Decode(
     'ChJUZW1wZXJhdHVyZVJlYWRpbmcSFAoFdmFsdWUYASABKAJSBXZhbHVlEhIKBHVuaXQYAiABKA'
-    'lSBHVuaXQ=');
+    'lSBHVuaXQSLAoSdXRjX29mZnNldF9zZWNvbmRzGAMgASgFUhB1dGNPZmZzZXRTZWNvbmRz');

--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:grpc/grpc.dart';
+import 'package:virtual_keyboard_multi_language/virtual_keyboard_multi_language.dart';
 
 import 'generated/temperature.pbgrpc.dart';
 
@@ -44,6 +45,7 @@ class TemperaturePage extends StatefulWidget {
 class _TemperaturePageState extends State<TemperaturePage> {
   double? _temperature;
   String _unit = 'C';
+  int _utcOffsetSeconds = 0;
   String? _error;
   bool _connected = false;
 
@@ -51,7 +53,6 @@ class _TemperaturePageState extends State<TemperaturePage> {
   late RPCClient _stub;
   StreamSubscription<TemperatureReading>? _subscription;
 
-  DateTime _currentTime = DateTime.now();
   late Timer? _timer;
 
   @override
@@ -60,9 +61,7 @@ class _TemperaturePageState extends State<TemperaturePage> {
     _connect();
 
     _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
-      setState(() {
-        _currentTime = DateTime.now();
-      });
+      if (mounted) setState(() {});
     });
   }
 
@@ -88,6 +87,7 @@ class _TemperaturePageState extends State<TemperaturePage> {
         setState(() {
           _temperature = reading.value;
           _unit = reading.unit;
+          _utcOffsetSeconds = reading.utcOffsetSeconds;
           _connected = true;
           _error = null;
         });
@@ -122,7 +122,9 @@ class _TemperaturePageState extends State<TemperaturePage> {
   void _openSettings() {
     Navigator.push(
       context,
-      MaterialPageRoute(builder: (_) => SettingsPage(stub: _stub)),
+      MaterialPageRoute(
+        builder: (_) => SettingsPage(stub: _stub, currentUnit: _unit),
+      ),
     );
   }
 
@@ -134,9 +136,13 @@ class _TemperaturePageState extends State<TemperaturePage> {
   String _formatTime() {
     String twoDigits(int n) => n.toString().padLeft(2, '0');
 
-    return "${twoDigits(_currentTime.hour)}:"
-        "${twoDigits(_currentTime.minute)}:"
-        "${twoDigits(_currentTime.second)}";
+    final local = DateTime.now().toUtc().add(
+      Duration(seconds: _utcOffsetSeconds),
+    );
+
+    return "${twoDigits(local.hour)}:"
+        "${twoDigits(local.minute)}:"
+        "${twoDigits(local.second)}";
   }
 
   @override
@@ -252,8 +258,13 @@ class _TemperaturePageState extends State<TemperaturePage> {
 
 class SettingsPage extends StatefulWidget {
   final RPCClient stub;
+  final String currentUnit;
 
-  const SettingsPage({super.key, required this.stub});
+  const SettingsPage({
+    super.key,
+    required this.stub,
+    required this.currentUnit,
+  });
 
   @override
   State<SettingsPage> createState() => _SettingsPageState();
@@ -261,7 +272,7 @@ class SettingsPage extends StatefulWidget {
 
 class _SettingsPageState extends State<SettingsPage> {
   // Unit
-  String _unit = 'C';
+  late String _unit;
   bool _unitBusy = false;
 
   // Timezone
@@ -274,10 +285,67 @@ class _SettingsPageState extends State<SettingsPage> {
   // Search
   final TextEditingController _searchController = TextEditingController();
   List<String> _filteredTimezones = [];
+  bool _shiftEnabled = false;
+
+  void _showKeyboard() {
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: const Color(0xFF16213E),
+      builder: (ctx) {
+        return StatefulBuilder(
+          builder: (ctx, setModalState) {
+            return VirtualKeyboard(
+              height: 300,
+              textColor: Colors.white,
+              fontSize: 16,
+              type: VirtualKeyboardType.Alphanumeric,
+              defaultLayouts: const [VirtualKeyboardDefaultLayouts.English],
+              postKeyPress: (key) {
+                if (key.keyType == VirtualKeyboardKeyType.String) {
+                  final char =
+                      _shiftEnabled ? (key.capsText ?? '') : (key.text ?? '');
+                  _searchController.text = _searchController.text + char;
+                  _searchController.selection = TextSelection.collapsed(
+                    offset: _searchController.text.length,
+                  );
+                } else if (key.keyType == VirtualKeyboardKeyType.Action) {
+                  switch (key.action) {
+                    case VirtualKeyboardKeyAction.Backspace:
+                      final text = _searchController.text;
+                      if (text.isNotEmpty) {
+                        _searchController.text = text.substring(
+                          0,
+                          text.length - 1,
+                        );
+                        _searchController.selection = TextSelection.collapsed(
+                          offset: _searchController.text.length,
+                        );
+                      }
+                    case VirtualKeyboardKeyAction.Space:
+                      _searchController.text = '${_searchController.text} ';
+                      _searchController.selection = TextSelection.collapsed(
+                        offset: _searchController.text.length,
+                      );
+                    case VirtualKeyboardKeyAction.Return:
+                      Navigator.pop(ctx);
+                    case VirtualKeyboardKeyAction.Shift:
+                      setModalState(() => _shiftEnabled = !_shiftEnabled);
+                    default:
+                      break;
+                  }
+                }
+              },
+            );
+          },
+        );
+      },
+    );
+  }
 
   @override
   void initState() {
     super.initState();
+    _unit = widget.currentUnit;
     _loadTimezones();
     _searchController.addListener(_onSearchChanged);
   }
@@ -432,6 +500,8 @@ class _SettingsPageState extends State<SettingsPage> {
           // Search field
           TextField(
             controller: _searchController,
+            readOnly: true,
+            onTap: _showKeyboard,
             style: const TextStyle(color: Colors.white),
             decoration: InputDecoration(
               hintText: 'Search timezones...',

--- a/lib/temperature.pb.ex
+++ b/lib/temperature.pb.ex
@@ -30,6 +30,7 @@ defmodule ThermostatNerves.TemperatureReading do
 
   field :value, 1, type: :float
   field :unit, 2, type: :string
+  field :utc_offset_seconds, 3, type: :int32, json_name: "utcOffsetSeconds"
 end
 
 defmodule ThermostatNerves.RPC.Service do

--- a/lib/thermostat_nerves/temperature/server.ex
+++ b/lib/thermostat_nerves/temperature/server.ex
@@ -73,8 +73,18 @@ defmodule ThermostatNerves.Server do
 
     %ThermostatNerves.TemperatureReading{
       value: value,
-      unit: unit
+      unit: unit,
+      utc_offset_seconds: utc_offset_seconds()
     }
+  end
+
+  defp utc_offset_seconds do
+    tz = NervesTimeZones.get_time_zone()
+
+    case DateTime.now(tz, Zoneinfo.TimeZoneDatabase) do
+      {:ok, dt} -> dt.utc_offset + dt.std_offset
+      _ -> 0
+    end
   end
 
   defp celsius_to_fahrenheit(celsius), do: celsius * 9 / 5 + 32

--- a/priv/protos/temperature.proto
+++ b/priv/protos/temperature.proto
@@ -49,7 +49,8 @@ service RPC {
 }
 
 message TemperatureReading {
-	float value = 1;  // Temperature value
-	string unit = 2;  // "C" for Celsius, "F" for Fahrenheit
+	float value = 1;             // Temperature value
+	string unit = 2;             // "C" for Celsius, "F" for Fahrenheit
+	int32 utc_offset_seconds = 3; // Current device UTC offset in seconds (e.g. -25200 for UTC-7)
 }
 

--- a/test/thermostat_nerves/temperature/server_test.exs
+++ b/test/thermostat_nerves/temperature/server_test.exs
@@ -94,6 +94,14 @@ defmodule ThermostatNerves.ServerTest do
       assert_in_delta fahrenheit_reading.value, 68.0, 0.01
       assert fahrenheit_reading.unit == "F"
     end
+
+    test "reading includes a utc_offset_seconds integer field" do
+      PropertyTable.put(SensorTable, ["temperature"], 20.0)
+
+      reading = Server.send_temperature(%ThermostatNerves.Empty{}, nil)
+
+      assert is_integer(reading.utc_offset_seconds)
+    end
   end
 
   describe "set_timezone/2" do


### PR DESCRIPTION
## Summary

- **Bug fix**: The °C/°F segmented button in `SettingsPage` always opened showing °C regardless of the current selection. Fixed by passing `currentUnit` from `TemperaturePage` as a constructor parameter so the button reflects the actual state on open.
- **Bug fix**: The timezone search `TextField` did not invoke a keyboard on embedded Linux/DRM Flutter. Fixed by making the field `readOnly` and showing a `VirtualKeyboard` (via the existing `virtual_keyboard_multi_language` dependency) in a `showModalBottomSheet` on tap.
- **Feature**: Home screen clock now shows the correct local time after a timezone change. Added `utc_offset_seconds` to the `TemperatureReading` proto message; the Elixir server computes it via `NervesTimeZones.get_time_zone/0` + `Zoneinfo.TimeZoneDatabase` on every reading. Flutter applies the offset to `DateTime.now().toUtc()` so the display updates within one stream tick (≤2 s) of a timezone change, with no new Flutter dependencies.

## Changes

- `priv/protos/temperature.proto` — added `int32 utc_offset_seconds = 3` to `TemperatureReading`
- `lib/temperature.pb.ex`, `flutter_app/lib/generated/temperature.pb.dart`, `flutter_app/lib/generated/temperature.pbjson.dart` — regenerated
- `lib/thermostat_nerves/temperature/server.ex` — populate `utc_offset_seconds` in `read_temperature/0`
- `flutter_app/lib/main.dart` — `SettingsPage` constructor + keyboard + clock fix
- `test/thermostat_nerves/temperature/server_test.exs` — one new test asserting `utc_offset_seconds` is an integer