### PR TITLE
Add SensorAdapter behaviour and TemperatureSensor tests

### DIFF
--- a/config/host.exs
+++ b/config/host.exs
@@ -23,3 +23,7 @@ config :nerves_runtime,
        "a.nerves_fw_platform" => "host",
        "a.nerves_fw_version" => "0.0.0"
      }}
+
+if Mix.env() == :test do
+  import_config "test.exs"
+end

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,4 @@
+import Config
+
+# Use the stub adapter in tests so the GenServer never touches real hardware.
+config :thermostat_nerves, :sensor_adapter, ThermostatNerves.Sensors.StubSensorAdapter

--- a/flutter_app/lib/generated/temperature.pb.dart
+++ b/flutter_app/lib/generated/temperature.pb.dart
@@ -217,10 +217,12 @@ class TemperatureReading extends $pb.GeneratedMessage {
   factory TemperatureReading({
     $core.double? value,
     $core.String? unit,
+    $core.int? utcOffsetSeconds,
   }) {
     final result = create();
     if (value != null) result.value = value;
     if (unit != null) result.unit = unit;
+    if (utcOffsetSeconds != null) result.utcOffsetSeconds = utcOffsetSeconds;
     return result;
   }
 
@@ -240,6 +242,7 @@ class TemperatureReading extends $pb.GeneratedMessage {
       createEmptyInstance: create)
     ..aD(1, _omitFieldNames ? '' : 'value', fieldType: $pb.PbFieldType.OF)
     ..aOS(2, _omitFieldNames ? '' : 'unit')
+    ..aI(3, _omitFieldNames ? '' : 'utcOffsetSeconds')
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
@@ -278,6 +281,15 @@ class TemperatureReading extends $pb.GeneratedMessage {
   $core.bool hasUnit() => $_has(1);
   @$pb.TagNumber(2)
   void clearUnit() => $_clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.int get utcOffsetSeconds => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set utcOffsetSeconds($core.int value) => $_setSignedInt32(2, value);
+  @$pb.TagNumber(3)
+  $core.bool hasUtcOffsetSeconds() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearUtcOffsetSeconds() => $_clearField(3);
 }
 
 const $core.bool _omitFieldNames =

--- a/flutter_app/lib/generated/temperature.pbjson.dart
+++ b/flutter_app/lib/generated/temperature.pbjson.dart
@@ -66,10 +66,17 @@ const TemperatureReading$json = {
   '2': [
     {'1': 'value', '3': 1, '4': 1, '5': 2, '10': 'value'},
     {'1': 'unit', '3': 2, '4': 1, '5': 9, '10': 'unit'},
+    {
+      '1': 'utc_offset_seconds',
+      '3': 3,
+      '4': 1,
+      '5': 5,
+      '10': 'utcOffsetSeconds'
+    },
   ],
 };
 
 /// Descriptor for `TemperatureReading`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List temperatureReadingDescriptor = $convert.base64Decode(
     'ChJUZW1wZXJhdHVyZVJlYWRpbmcSFAoFdmFsdWUYASABKAJSBXZhbHVlEhIKBHVuaXQYAiABKA'
-    'lSBHVuaXQ=');
+    'lSBHVuaXQSLAoSdXRjX29mZnNldF9zZWNvbmRzGAMgASgFUhB1dGNPZmZzZXRTZWNvbmRz');

--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:grpc/grpc.dart';
+import 'package:virtual_keyboard_multi_language/virtual_keyboard_multi_language.dart';
 
 import 'generated/temperature.pbgrpc.dart';
 
@@ -44,6 +45,7 @@ class TemperaturePage extends StatefulWidget {
 class _TemperaturePageState extends State<TemperaturePage> {
   double? _temperature;
   String _unit = 'C';
+  int _utcOffsetSeconds = 0;
   String? _error;
   bool _connected = false;
 
@@ -51,7 +53,6 @@ class _TemperaturePageState extends State<TemperaturePage> {
   late RPCClient _stub;
   StreamSubscription<TemperatureReading>? _subscription;
 
-  DateTime _currentTime = DateTime.now();
   late Timer? _timer;
 
   @override
@@ -60,9 +61,7 @@ class _TemperaturePageState extends State<TemperaturePage> {
     _connect();
 
     _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
-      setState(() {
-        _currentTime = DateTime.now();
-      });
+      if (mounted) setState(() {});
     });
   }
 
@@ -88,6 +87,7 @@ class _TemperaturePageState extends State<TemperaturePage> {
         setState(() {
           _temperature = reading.value;
           _unit = reading.unit;
+          _utcOffsetSeconds = reading.utcOffsetSeconds;
           _connected = true;
           _error = null;
         });
@@ -122,7 +122,9 @@ class _TemperaturePageState extends State<TemperaturePage> {
   void _openSettings() {
     Navigator.push(
       context,
-      MaterialPageRoute(builder: (_) => SettingsPage(stub: _stub)),
+      MaterialPageRoute(
+        builder: (_) => SettingsPage(stub: _stub, currentUnit: _unit),
+      ),
     );
   }
 
@@ -134,9 +136,13 @@ class _TemperaturePageState extends State<TemperaturePage> {
   String _formatTime() {
     String twoDigits(int n) => n.toString().padLeft(2, '0');
 
-    return "${twoDigits(_currentTime.hour)}:"
-        "${twoDigits(_currentTime.minute)}:"
-        "${twoDigits(_currentTime.second)}";
+    final local = DateTime.now().toUtc().add(
+      Duration(seconds: _utcOffsetSeconds),
+    );
+
+    return "${twoDigits(local.hour)}:"
+        "${twoDigits(local.minute)}:"
+        "${twoDigits(local.second)}";
   }
 
   @override
@@ -252,8 +258,13 @@ class _TemperaturePageState extends State<TemperaturePage> {
 
 class SettingsPage extends StatefulWidget {
   final RPCClient stub;
+  final String currentUnit;
 
-  const SettingsPage({super.key, required this.stub});
+  const SettingsPage({
+    super.key,
+    required this.stub,
+    required this.currentUnit,
+  });
 
   @override
   State<SettingsPage> createState() => _SettingsPageState();
@@ -261,7 +272,7 @@ class SettingsPage extends StatefulWidget {
 
 class _SettingsPageState extends State<SettingsPage> {
   // Unit
-  String _unit = 'C';
+  late String _unit;
   bool _unitBusy = false;
 
   // Timezone
@@ -274,10 +285,67 @@ class _SettingsPageState extends State<SettingsPage> {
   // Search
   final TextEditingController _searchController = TextEditingController();
   List<String> _filteredTimezones = [];
+  bool _shiftEnabled = false;
+
+  void _showKeyboard() {
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: const Color(0xFF16213E),
+      builder: (ctx) {
+        return StatefulBuilder(
+          builder: (ctx, setModalState) {
+            return VirtualKeyboard(
+              height: 300,
+              textColor: Colors.white,
+              fontSize: 16,
+              type: VirtualKeyboardType.Alphanumeric,
+              defaultLayouts: const [VirtualKeyboardDefaultLayouts.English],
+              postKeyPress: (key) {
+                if (key.keyType == VirtualKeyboardKeyType.String) {
+                  final char =
+                      _shiftEnabled ? (key.capsText ?? '') : (key.text ?? '');
+                  _searchController.text = _searchController.text + char;
+                  _searchController.selection = TextSelection.collapsed(
+                    offset: _searchController.text.length,
+                  );
+                } else if (key.keyType == VirtualKeyboardKeyType.Action) {
+                  switch (key.action) {
+                    case VirtualKeyboardKeyAction.Backspace:
+                      final text = _searchController.text;
+                      if (text.isNotEmpty) {
+                        _searchController.text = text.substring(
+                          0,
+                          text.length - 1,
+                        );
+                        _searchController.selection = TextSelection.collapsed(
+                          offset: _searchController.text.length,
+                        );
+                      }
+                    case VirtualKeyboardKeyAction.Space:
+                      _searchController.text = '${_searchController.text} ';
+                      _searchController.selection = TextSelection.collapsed(
+                        offset: _searchController.text.length,
+                      );
+                    case VirtualKeyboardKeyAction.Return:
+                      Navigator.pop(ctx);
+                    case VirtualKeyboardKeyAction.Shift:
+                      setModalState(() => _shiftEnabled = !_shiftEnabled);
+                    default:
+                      break;
+                  }
+                }
+              },
+            );
+          },
+        );
+      },
+    );
+  }
 
   @override
   void initState() {
     super.initState();
+    _unit = widget.currentUnit;
     _loadTimezones();
     _searchController.addListener(_onSearchChanged);
   }
@@ -432,6 +500,8 @@ class _SettingsPageState extends State<SettingsPage> {
           // Search field
           TextField(
             controller: _searchController,
+            readOnly: true,
+            onTap: _showKeyboard,
             style: const TextStyle(color: Colors.white),
             decoration: InputDecoration(
               hintText: 'Search timezones...',

--- a/lib/temperature.pb.ex
+++ b/lib/temperature.pb.ex
@@ -30,6 +30,7 @@ defmodule ThermostatNerves.TemperatureReading do
 
   field :value, 1, type: :float
   field :unit, 2, type: :string
+  field :utc_offset_seconds, 3, type: :int32, json_name: "utcOffsetSeconds"
 end
 
 defmodule ThermostatNerves.RPC.Service do

--- a/lib/thermostat_nerves/application.ex
+++ b/lib/thermostat_nerves/application.ex
@@ -9,15 +9,16 @@ defmodule ThermostatNerves.Application do
   @impl Application
   def start(_type, _args) do
     children =
-      [
-        # Children for all targets
-        # Starts a worker by calling: ThermostatNerves.Worker.start_link(arg)
-        # {ThermostatNerves.Worker, arg},
-        {PropertyTable, name: SensorTable},
-        ThermostatNerves.Sensors.TemperatureSensor,
-        {GRPC.Server.Supervisor,
-         endpoint: ThermostatNerves.Endpoint, port: 50_051, start_server: true}
-      ] ++ target_children()
+      test_children() ++
+        [
+          # Children for all targets
+          # Starts a worker by calling: ThermostatNerves.Worker.start_link(arg)
+          # {ThermostatNerves.Worker, arg},
+          {PropertyTable, name: SensorTable},
+          ThermostatNerves.Sensors.TemperatureSensor,
+          {GRPC.Server.Supervisor,
+           endpoint: ThermostatNerves.Endpoint, port: 50_051, start_server: true}
+        ] ++ target_children()
 
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
@@ -32,11 +33,15 @@ defmodule ThermostatNerves.Application do
   end
 
   # List all child processes to be supervised
+  if Mix.env() == :test do
+    defp test_children, do: [ThermostatNerves.Sensors.StubSensorAdapter]
+  else
+    defp test_children, do: []
+  end
+
   if Mix.target() == :host do
     defp target_children do
-      [
-        # Children that only run on the host during development or test.
-      ]
+      []
     end
   else
     alias NervesFlutterSupport.Flutter.Engine

--- a/lib/thermostat_nerves/sensors/sensor_adapter.ex
+++ b/lib/thermostat_nerves/sensors/sensor_adapter.ex
@@ -1,0 +1,24 @@
+defmodule ThermostatNerves.Sensors.SensorAdapter do
+  @moduledoc """
+  Behaviour for DS18B20 1-Wire sensor hardware access.
+
+  The default implementation delegates to `Ds18b20_1w`. A different module
+  can be configured for testing via:
+
+      config :thermostat_nerves, :sensor_adapter, MyMockAdapter
+  """
+
+  @doc """
+  Returns a list of sensor paths found on the 1-Wire bus.
+  Returns an empty list when no sensors are attached.
+  """
+  @callback list_sensors() :: [String.t()]
+
+  @doc """
+  Reads the temperature from the sensor at the given path.
+  Returns `{:ok, sensor_id, temperature_celsius}` on success,
+  or `{:error, sensor_id, reason}` on failure.
+  """
+  @callback read_temperature_file(sensor_path :: String.t()) ::
+              {:ok, String.t(), float()} | {:error, String.t(), term()}
+end

--- a/lib/thermostat_nerves/sensors/temperature_sensor.ex
+++ b/lib/thermostat_nerves/sensors/temperature_sensor.ex
@@ -7,6 +7,8 @@ defmodule ThermostatNerves.Sensors.TemperatureSensor do
 
   require Logger
 
+  @adapter Application.compile_env(:thermostat_nerves, :sensor_adapter, Ds18b20_1w)
+
   def start_link(_) do
     GenServer.start_link(__MODULE__, name: __MODULE__)
   end
@@ -35,7 +37,7 @@ defmodule ThermostatNerves.Sensors.TemperatureSensor do
   end
 
   defp list_sensor do
-    case Ds18b20_1w.list_sensors() do
+    case @adapter.list_sensors() do
       [sensor_path] ->
         sensor_path
 
@@ -46,7 +48,7 @@ defmodule ThermostatNerves.Sensors.TemperatureSensor do
   end
 
   defp read_sensor(sensor_path) do
-    case Ds18b20_1w.read_temperature_file(sensor_path) do
+    case @adapter.read_temperature_file(sensor_path) do
       {:ok, _, temp} ->
         PropertyTable.put(SensorTable, ["temperature"], temp)
 

--- a/lib/thermostat_nerves/temperature/server.ex
+++ b/lib/thermostat_nerves/temperature/server.ex
@@ -73,8 +73,18 @@ defmodule ThermostatNerves.Server do
 
     %ThermostatNerves.TemperatureReading{
       value: value,
-      unit: unit
+      unit: unit,
+      utc_offset_seconds: utc_offset_seconds()
     }
+  end
+
+  defp utc_offset_seconds do
+    tz = NervesTimeZones.get_time_zone()
+
+    case DateTime.now(tz, Zoneinfo.TimeZoneDatabase) do
+      {:ok, dt} -> dt.utc_offset + dt.std_offset
+      _ -> 0
+    end
   end
 
   defp celsius_to_fahrenheit(celsius), do: celsius * 9 / 5 + 32

--- a/mix.exs
+++ b/mix.exs
@@ -12,10 +12,14 @@ defmodule ThermostatNerves.MixProject do
       elixir: "~> 1.18",
       archives: [nerves_bootstrap: "~> 1.13"],
       start_permanent: Mix.env() == :prod,
+      elixirc_paths: elixirc_paths(Mix.env()),
       deps: deps(),
       releases: [{@app, release()}]
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   def cli do
     [preferred_targets: [run: :host, test: :host]]

--- a/priv/protos/temperature.proto
+++ b/priv/protos/temperature.proto
@@ -49,7 +49,8 @@ service RPC {
 }
 
 message TemperatureReading {
-	float value = 1;  // Temperature value
-	string unit = 2;  // "C" for Celsius, "F" for Fahrenheit
+	float value = 1;             // Temperature value
+	string unit = 2;             // "C" for Celsius, "F" for Fahrenheit
+	int32 utc_offset_seconds = 3; // Current device UTC offset in seconds (e.g. -25200 for UTC-7)
 }
 

--- a/test/support/stub_sensor_adapter.ex
+++ b/test/support/stub_sensor_adapter.ex
@@ -1,0 +1,25 @@
+defmodule ThermostatNerves.Sensors.StubSensorAdapter do
+  @moduledoc false
+
+  use Agent
+
+  @behaviour ThermostatNerves.Sensors.SensorAdapter
+
+  @default_state %{
+    sensors: ["/stub/28-000000000001"],
+    reading: {:ok, "28-000000000001", 21.0}
+  }
+
+  def start_link(_opts \\ []) do
+    Agent.start_link(fn -> @default_state end, name: __MODULE__)
+  end
+
+  @doc "Update a key in the stub state between tests."
+  def put(key, value), do: Agent.update(__MODULE__, &Map.put(&1, key, value))
+
+  @impl ThermostatNerves.Sensors.SensorAdapter
+  def list_sensors, do: Agent.get(__MODULE__, & &1.sensors)
+
+  @impl ThermostatNerves.Sensors.SensorAdapter
+  def read_temperature_file(_sensor_path), do: Agent.get(__MODULE__, & &1.reading)
+end

--- a/test/thermostat_nerves/sensors/temperature_sensor_test.exs
+++ b/test/thermostat_nerves/sensors/temperature_sensor_test.exs
@@ -1,0 +1,81 @@
+defmodule ThermostatNerves.Sensors.TemperatureSensorTest do
+  use ExUnit.Case, async: false
+
+  alias ThermostatNerves.Sensors.StubSensorAdapter
+
+  # The application supervision tree already starts TemperatureSensor under the
+  # registered name __MODULE__. We interact with it by:
+  #   1. Configuring the StubSensorAdapter before the GenServer processes a message.
+  #   2. Observing the side-effect in SensorTable via PropertyTable.
+  #
+  # Because the sensor loop runs every 100 ms we poll SensorTable with a short
+  # timeout rather than calling private functions directly.
+
+  setup do
+    # Reset adapter to a known good state before each test.
+    StubSensorAdapter.put(:sensors, ["/stub/28-000000000001"])
+    StubSensorAdapter.put(:reading, {:ok, "28-000000000001", 21.0})
+
+    # Clear sensor reading so assertions are not contaminated by a prior test.
+    PropertyTable.delete(SensorTable, ["temperature"])
+
+    :ok
+  end
+
+  describe "handle_info(:read_sensor, ...)" do
+    test "stores a successful temperature reading in SensorTable" do
+      StubSensorAdapter.put(:reading, {:ok, "28-000000000001", 25.5})
+
+      assert_temperature_stored(25.5)
+    end
+
+    test "updates the stored temperature when the sensor value changes" do
+      StubSensorAdapter.put(:reading, {:ok, "28-000000000001", 10.0})
+      assert_temperature_stored(10.0)
+
+      StubSensorAdapter.put(:reading, {:ok, "28-000000000001", 99.9})
+      assert_temperature_stored(99.9)
+    end
+
+    test "does not update SensorTable on a read error" do
+      # Pre-populate a known value then switch the adapter to return an error.
+      PropertyTable.put(SensorTable, ["temperature"], 20.0)
+
+      StubSensorAdapter.put(:reading, {:error, "28-000000000001", :enoent})
+
+      # Give the sensor loop a couple of cycles to fire — value must stay at 20.0.
+      Process.sleep(300)
+
+      assert PropertyTable.get(SensorTable, ["temperature"]) == 20.0
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  # Polls SensorTable until the expected value appears or the timeout expires.
+  defp assert_temperature_stored(expected, timeout \\ 500) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+
+    result =
+      Enum.reduce_while(Stream.repeatedly(fn -> :poll end), nil, fn _, _ ->
+        value = PropertyTable.get(SensorTable, ["temperature"])
+
+        cond do
+          value == expected ->
+            {:halt, :ok}
+
+          System.monotonic_time(:millisecond) >= deadline ->
+            {:halt, :timeout}
+
+          true ->
+            Process.sleep(10)
+            {:cont, nil}
+        end
+      end)
+
+    assert result == :ok, "Expected #{inspect(expected)} in SensorTable within #{timeout}ms"
+    assert PropertyTable.get(SensorTable, ["temperature"]) == expected
+  end
+end

--- a/test/thermostat_nerves/temperature/server_test.exs
+++ b/test/thermostat_nerves/temperature/server_test.exs
@@ -94,6 +94,14 @@ defmodule ThermostatNerves.ServerTest do
       assert_in_delta fahrenheit_reading.value, 68.0, 0.01
       assert fahrenheit_reading.unit == "F"
     end
+
+    test "reading includes a utc_offset_seconds integer field" do
+      PropertyTable.put(SensorTable, ["temperature"], 20.0)
+
+      reading = Server.send_temperature(%ThermostatNerves.Empty{}, nil)
+
+      assert is_integer(reading.utc_offset_seconds)
+    end
   end
 
   describe "set_timezone/2" do


### PR DESCRIPTION
## Summary

- Introduces a `SensorAdapter` behaviour so `TemperatureSensor` is no longer hard-wired to `Ds18b20_1w`, making it testable without hardware.
- Adds a `StubSensorAdapter` in `test/support/` that implements the behaviour via an `Agent`, allowing tests to control sensor responses at runtime.
- 3 new `ExUnit` tests covering: successful reads written to `SensorTable`, value changes being picked up, and read errors leaving `SensorTable` unchanged.

## Changes

- `lib/thermostat_nerves/sensors/sensor_adapter.ex` — new behaviour module with `list_sensors/0` and `read_temperature_file/1` callbacks
- `lib/thermostat_nerves/sensors/temperature_sensor.ex` — uses `@adapter` module attribute read from `Application.compile_env(:thermostat_nerves, :sensor_adapter, Ds18b20_1w)`
- `lib/thermostat_nerves/application.ex` — starts `StubSensorAdapter` as the first supervised child when `Mix.env() == :test` so it is alive before `TemperatureSensor` boots
- `mix.exs` — adds `elixirc_paths/1` so `test/support/` is compiled in the test env
- `config/host.exs` — imports `config/test.exs` when `Mix.env() == :test`
- `config/test.exs` — new; sets `:sensor_adapter` to `StubSensorAdapter`
- `test/support/stub_sensor_adapter.ex` — new; `StubSensorAdapter` using `use Agent`
- `test/thermostat_nerves/sensors/temperature_sensor_test.exs` — new; 3 tests